### PR TITLE
Add 5 new tools to cpt.yaml

### DIFF
--- a/cpt.yaml
+++ b/cpt.yaml
@@ -48,3 +48,22 @@ tools:
     owner: cpt
     tool_panel_section_label: Annotation
 
+  - name: cpt_convert_glimmer
+    owner: cpt
+    tool_panel_section_label: Annotation
+
+  - name: cpt_get_orfs
+    owner: cpt
+    tool_panel_section_label: Annotation
+
+  - name: cpt_gff_add_parents
+    owner: cpt
+    tool_panel_section_label: Annotation
+
+  - name: cpt_req_phage_start
+    owner: cpt
+    tool_panel_section_label: Annotation
+
+  - name: cpt_fix_sixpack
+    owner: cpt
+    tool_panel_section_label: Annotation


### PR DESCRIPTION
Add 5 new tools to cpt.yaml to have all tools needed to build the phage structural workflow:
cpt_convert_glimmer
cpt_get_orfs
cpt_gff_add_parents
cpt_req_phage_start
cpt_fix_sixpack